### PR TITLE
Feat/text 공통 디자인 컴포넌트 Text 추가

### DIFF
--- a/apps/mongle-webview/app/version/_components/version.tsx
+++ b/apps/mongle-webview/app/version/_components/version.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Button } from '@mgmg/ui/ui';
+import { Button, Text } from '@mgmg/ui/ui';
 import React from 'react';
 import revision from 'revision.json';
 const Version = () => {
@@ -9,6 +9,9 @@ const Version = () => {
       <div>branch: {revision.branch}</div>
       <div>lastCommit: {revision.lastCommitDate}</div>
       <Button>Click</Button>
+      <Text typography="sm-b" color="warning">
+        Test Text
+      </Text>
     </div>
   );
 };

--- a/packages/ui/global.css
+++ b/packages/ui/global.css
@@ -7,9 +7,17 @@
     --foreground: 0 0% 3.9%;
     --card: 0 0% 100%;
     --card-foreground: 0 0% 3.9%;
+    --text-primary: #688edc;
+    --text-default: #000000;
+    --text-secondary: #313438;
+    --text-third: #535961;
+    --text-muted: #8b95a1;
+    --text-destructive: #688edc;
+    --text-white: #ffffff;
+    --text-warning: #ff6a69;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
+    --primary: #688edc;
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;
@@ -27,7 +35,8 @@
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 0.5rem}
+    --radius: 0.5rem;
+  }
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
@@ -52,7 +61,8 @@
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%}
+    --chart-5: 340 75% 55%;
+  }
 }
 @layer base {
   * {

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -2,8 +2,7 @@
 // export { setupCounter } from '../lib/utils/counter';
 
 // components
-export { Header } from './header';
-export { Button } from './ui/button';
+export * from './ui';
 
 // utils
 export { cn } from './lib/utils';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
     "./setup-counter": "./utils/counter.ts",
     "./utils": "./lib/utils.ts",
     "./global/styles": "./global.css",
-    "./tailwind": "./tailwind.config.ts",
+    "./tailwind": "./tailwind/tailwind.config.ts",
     "./ui": "./ui/index.ts"
   },
   "license": "MIT",

--- a/packages/ui/tailwind/tailwind.config.ts
+++ b/packages/ui/tailwind/tailwind.config.ts
@@ -1,4 +1,5 @@
 import { Config } from 'tailwindcss';
+import { typography } from './typography';
 const config: Config = {
   darkMode: ['class'],
   content: ['./ui/**/*.{js,ts,jsx,tsx,mdx}', './components/**/*.{js,ts,jsx,tsx,mdx}'],
@@ -8,6 +9,9 @@ const config: Config = {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
+      },
+      fontSize: {
+        ...typography,
       },
       colors: {
         background: 'hsl(var(--background))',
@@ -20,8 +24,18 @@ const config: Config = {
           DEFAULT: 'hsl(var(--popover))',
           foreground: 'hsl(var(--popover-foreground))',
         },
+        text: {
+          primary: 'var(--text-primary)',
+          black: 'var(--text-black)',
+          secondary: 'var(--text-secondary)',
+          third: 'var(--text-third)',
+          muted: 'var(--text-muted)',
+          destructive: 'var(--text-destructive)',
+          white: 'var(--text-white)',
+          warning: 'var(--text-warning)',
+        },
         primary: {
-          DEFAULT: 'hsl(var(--primary))',
+          DEFAULT: 'var(--primary)',
           foreground: 'hsl(var(--primary-foreground))',
         },
         secondary: {

--- a/packages/ui/tailwind/typography.ts
+++ b/packages/ui/tailwind/typography.ts
@@ -1,0 +1,9 @@
+export const typography: { [key: string]: [string, string] } = {
+  xs: ['12px', '18px'],
+  sm: ['14px', '20px'],
+  md: ['16px', '24px'],
+  lg: ['18px', '27px'],
+  xl: ['20px', '30px'],
+  '2xl': ['22px', '33px'],
+  '3xl': ['24px', '36px'],
+};

--- a/packages/ui/ui/Text.tsx
+++ b/packages/ui/ui/Text.tsx
@@ -1,0 +1,48 @@
+import { cn } from '@mgmg/ui/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+const textVariants = cva('text-sm font-medium text-text-default', {
+  variants: {
+    typography: {
+      default: 'text-sm font-medium',
+      'sm-b': 'text-sm font-semibold',
+      'sm-m': 'text-sm font-medium',
+      'sm-r': 'text-sm font-regular',
+      'md-b': 'text-md font-semibold',
+      'md-m': 'text-md font-medium',
+      'md-r': 'text-md font-regular',
+      'lg-b': 'text-lg font-semibold',
+      'lg-m': 'text-lg font-medium',
+      'lg-r': 'text-lg font-regular',
+      'xl-b': 'text-xl font-semibold',
+      'xl-m': 'text-xl font-medium',
+      'xl-r': 'text-xl font-regular',
+      '2xl-b': 'text-2xl font-semibold',
+      '2xl-m': 'text-2xl font-medium',
+      '2xl-r': 'text-2xl font-regular',
+    },
+    color: {
+      default: 'text-text-default',
+      primary: 'text-text-primary',
+      secondary: 'text-text-secondary',
+      third: 'text-text-third',
+      muted: 'text-text-muted',
+      destructive: 'text-text-destructive',
+      white: 'text-text-white',
+      warning: 'text-text-warning',
+    },
+  },
+  defaultVariants: {
+    typography: 'default',
+    color: 'default',
+  },
+});
+
+export interface TextProps extends VariantProps<typeof textVariants> {
+  children: React.ReactNode;
+}
+
+export const Text = ({ children, typography, color }: TextProps) => {
+  return <span className={cn(textVariants({ typography, color }))}>{children}</span>;
+};

--- a/packages/ui/ui/index.ts
+++ b/packages/ui/ui/index.ts
@@ -1,2 +1,3 @@
 export { Button, type ButtonProps } from './button';
+export { Text, type TextProps } from './Text';
 export { Header } from './header';


### PR DESCRIPTION
## 🎫 [지라 티켓 번호]

<br>

<br>

## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->

## 공통 디자인 컴포넌트 추가

공통으로 사용할 Text 컴포넌트 추가하였습니다.

피그마에서 많이 사용되는 것 위주로 구성하였습니다.

피그마에 13px 15px 처럼 애매하게 사용되는 font-size들이 있는데 

해당 부분들은 12px 이나 14px로 통일 시키는것이 좋아 보입니다. 추후에 회의 때 

정리해서 유빈님과 한번 얘기 해보겠습니다.

### 사용방법

사용방법은 `font-size, font-weight, line-height` 가 하나로 뭉쳐져있는 `typograpy` props와

color값을 지정해줄수있는 `color` props로 이루어져있습니다.

아무것도 지정해주지 않을경우 기본 스타일이 들어갑니다.
```css
//기본스타일
font-size: 14px;
font-weight: 400;
line-height: 18px;
color: #000000;
```

```html
<Text typography='sm-b' color='secondary'> test text <Text/>
```

#### 왜 typograpy 하나로 뭉쳐두었는가?
line-height의 경우 font-size의 크기의 1.5배를 설정해주는것이 보편적인 예시이고, (잘 바뀌지 않는다는 뜻)

작업시에 font-size랑 font-weight를 한땀한땀 입력해주는것보다 한번에 사용하는것이

개발 생산성이 훨씬 빨라 질듯하여 하나로 뭉쳐두었습니다.

### tailwind 값 추가
공통으로 쓰일 color값이나 size등등 tailwind에 custom값 추가가 필요하다면 

1. `packages/ui/global.css` 파일에 :root에 색상값을 추가 (:root가 light이고 .dark가 dark모드일때 사용될 색상값)

```css
// global.css 파일

@tailwind base;
@tailwind components;
@tailwind utilities;
@layer base {
  :root {
    --background: 0 0% 100%;
    --foreground: 0 0% 3.9%;
    // 해당 부분에 추가
......
```

2. global.css에서 정의한 명을 가지고 `packages/ui/tailwind/tailwind.config.ts` 파일에 추가

```ts
// tailwind.config.ts 파일
.....
colors: {
    background: 'hsl(var(--background))',
    // 해당 부분에 추가, 혹은 적절한곳에 추가
}
```

현재 color값 사용할때는

`var(--text-primary)` 이런 css variable 형태로 작업이 되어 있는데,

후에 dark 모드가 생길수도 있어서 이렇게 사용하였습니다.

현재는 dark모드 색상이 따로 정의되어 있지 않아서 global.css의 .dark 에는 따로 색상값을 추가하지 않았습니다.

## 적용된 모습

Test Text에 Text 컴포넌트를 적용한 모습입니다.

![image](https://github.com/user-attachments/assets/98807faf-38f0-4a5e-ba80-d46ccafe024f)



<br>

<br>

## 📱 작업 화면
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|화면 이름|스크린샷|
|:--:|:--:|
|ViewName|<img src = "" width ="250">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
